### PR TITLE
added field label to segment_fields

### DIFF
--- a/app/Models/SegmentField.php
+++ b/app/Models/SegmentField.php
@@ -16,6 +16,7 @@ class SegmentField extends Model
     protected $fillable = [
         'field_name',
         'field_data_type',
+        'field_label',
         'segment_type_id',
         'type_name',
     ];

--- a/database/factories/SegmentFactory.php
+++ b/database/factories/SegmentFactory.php
@@ -3,10 +3,12 @@
 namespace Database\Factories;
 
 use App\Models\Reporter;
+use App\Models\SegmentField;
 use App\Models\User;
 use App\Models\InternalSystem;
 use App\Models\SegmentType;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -21,13 +23,25 @@ class SegmentFactory extends Factory
      */
     public function definition(): array
     {
+        $reportsegmentfields = SegmentField::all()->where('segment_type_id','=',1);
+
+        $segmentData = array();
+
+        foreach ($reportsegmentfields as $field)
+        {
+            $segmentData[$field->field_name] = $this->faker->sentence(7);
+        }
+
+        $segmentDataJson=json_encode($segmentData);
+
+
         return [
             'title' => $this->faker->sentence,
-            'segment_data' => $this->faker->paragraph,
-            // 'image' => $this->faker->sentence,
+            'segment_data' => $segmentDataJson,
+            'segment_image' => $this->faker->sentence,
             'user_id' => User::all()->random(),
             'internal_system_id' => InternalSystem::all()->random(),
             'segment_type_id' => SegmentType::all()->random(),
-        ]; 
+        ];
     }
 }

--- a/database/factories/SegmentFieldFactory.php
+++ b/database/factories/SegmentFieldFactory.php
@@ -18,11 +18,13 @@ class SegmentFieldFactory extends Factory
      */
     public function definition(): array
     {
-    
+
+        // force seeding segmentfields to be linked to report segment_type
         return [
-            'segment_type_id' => SegmentType::all()->random(),
-            'field_name' => $this->faker->sentence,
-            'field_data_type' => $this->faker->sentence,
+            'segment_type_id' => 1,
+            'field_name' => $this->faker->word(),
+            'field_data_type' => $this->faker->randomElement(['text','textarea']),
+            'field_data_type' => "text",
         ];
     }
 }

--- a/database/factories/SegmentFieldFactory.php
+++ b/database/factories/SegmentFieldFactory.php
@@ -23,8 +23,8 @@ class SegmentFieldFactory extends Factory
         return [
             'segment_type_id' => 1,
             'field_name' => $this->faker->word(),
+            'field_label' => $this->faker->word(),
             'field_data_type' => $this->faker->randomElement(['text','textarea']),
-            'field_data_type' => "text",
         ];
     }
 }

--- a/database/migrations/2023_05_27_140805_add_field_label_column.php
+++ b/database/migrations/2023_05_27_140805_add_field_label_column.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('segment_fields',function(Blueprint $table){
+            $table->text('field_label');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropColumns('segment_fields','field_label');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -39,20 +39,20 @@ class DatabaseSeeder extends Seeder
         Segment::truncate();
         Script::truncate();
         ScheduledSegment::truncate();
-        
+
         Music::factory()->count(4)->create();
         User::factory()->count(2)->create();
         Reporter::factory()->count(2)->create();
         Producer::factory()->count(2)->create();
         Type::factory()->count(3)->create();
-        SegmentType::factory()->count(3)->create();
+        SegmentType::factory()->count(1)->create();
         SubSegmentType::factory()->count(3)->create();
-        SegmentField::factory()->count(3)->create();
-        InternalSystem::factory()->count(1)->create();
+        SegmentField::factory()->count(5)->create();
+        InternalSystem::factory()->count(3)->create();
         Project::factory()->count(4)->create();
-        Segment::factory()->count(4)->create();
-        Script::factory()->count(4)->create();
+        Segment::factory()->count(15)->create();
+        Script::factory()->count(30)->create();
         ScheduledSegment::factory()->count(4)->create();
-            
+
     }
 }


### PR DESCRIPTION
Adding a common name column for fields, so that we can have the following structure:

- `field_name` - name to be used on the form. cannot contain spaces (ie. report-headline)
- `field_label` - common label that end user sees, that labels the form. can be any text (ie. Report Headline)
- `field_data_type` - input type for the form element. can be of type `text`, `textarea`, `number`, `date`


| id | field_label | segment_type_id | field_name | field_data_type |
|---|---|---|---|---|
|1| Report Headline | 1 | report-headline | text |


```blade
<!-- so this -->
<label>{{ $segmentField->field_label }}</label>
<input type="{{ $segmentField->field_data_type }}" name="{{ $segmentField->field_name }}" />

<!-- renders as this -->
<label>Report Headline</label>
<input type="text" name="report-headline" />
```